### PR TITLE
Auth

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import {Colors} from 'react-native/Libraries/NewAppScreen';
 import {ThemeProvider} from './src/contexts/ThemeContext.tsx';
 import {PlayerProvider} from './src/contexts/PlayerContext.tsx';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {AuthProvider} from './src/contexts/AuthContext.tsx';
 
 const queryClient = new QueryClient();
 
@@ -19,19 +20,21 @@ function App(): React.JSX.Element {
 
   return (
     <GestureHandlerRootView style={{flex: 1}}>
-      <QueryClientProvider client={queryClient}>
-        <ThemeProvider>
-          <PlayerProvider>
-            <StatusBar
-              animated={true}
-              barStyle={isDarkMode ? 'light-content' : 'dark-content'}
-              backgroundColor={backgroundStyle.backgroundColor}
-            />
+      <AuthProvider>
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider>
+            <PlayerProvider>
+              <StatusBar
+                animated={true}
+                barStyle={isDarkMode ? 'light-content' : 'dark-content'}
+                backgroundColor={backgroundStyle.backgroundColor}
+              />
 
-            <StackNavigator />
-          </PlayerProvider>
-        </ThemeProvider>
-      </QueryClientProvider>
+              <StackNavigator />
+            </PlayerProvider>
+          </ThemeProvider>
+        </QueryClientProvider>
+      </AuthProvider>
     </GestureHandlerRootView>
   );
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@react-navigation/stack": "^6.3.29",
     "@tanstack/react-query": "^5.35.1",
     "react": "18.2.0",
+    "react-hook-form": "^7.51.4",
     "react-native": "0.73.6",
     "react-native-gesture-handler": "^2.16.0",
     "react-native-linear-gradient": "^2.8.3",

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -7,7 +7,16 @@ export const apiRequest = async <T>(
   const response = await fetch(config.API_URL + endpoint, options);
 
   if (!response.ok) {
-    throw new Error('Network response was not ok');
+    let errorData;
+    try {
+      errorData = await response.json();
+    } catch (e) {
+      console.error(e);
+      throw new Error(
+        'Network response was not ok and error data could not be parsed',
+      );
+    }
+    throw new ApiError(response.status, errorData);
   }
 
   const data = await response.json();
@@ -31,3 +40,14 @@ export const apiPost = async <T>(
     body: JSON.stringify(data),
   });
 };
+
+export class ApiError extends Error {
+  status: number;
+  data: any;
+
+  constructor(status: number, data: any) {
+    super(data.message || 'API Error');
+    this.status = status;
+    this.data = data;
+  }
+}

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -1,4 +1,5 @@
 import config from '../constants/config.ts';
+import {FieldValues, UseFormSetError} from 'react-hook-form';
 
 export const apiRequest = async <T>(
   endpoint: string | URL | Request,
@@ -49,9 +50,15 @@ export const apiPost = async <T>(
   });
 };
 
+type ApiErrorResponse = {
+  error_type: string;
+  message: string;
+  errors: Record<string, string[]>;
+};
+
 export class ApiError extends Error {
   status: number;
-  data: any;
+  data: ApiErrorResponse;
 
   constructor(status: number, data: any) {
     super(data.message || 'API Error');
@@ -60,6 +67,15 @@ export class ApiError extends Error {
   }
 }
 
-export class ApiValidationError extends ApiError {}
+export class ApiValidationError extends ApiError {
+  fillFormErrors(setError: UseFormSetError<FieldValues>) {
+    Object.keys(this.data.errors).forEach(field => {
+      setError(field as keyof FieldValues, {
+        type: 'server',
+        message: this.data.errors[field][0],
+      });
+    });
+  }
+}
 
 export class ApiCommonError extends ApiError {}

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -16,7 +16,15 @@ export const apiRequest = async <T>(
         'Network response was not ok and error data could not be parsed',
       );
     }
-    throw new ApiError(response.status, errorData);
+
+    switch (errorData?.error_type) {
+      case 'validation':
+        throw new ApiValidationError(response.status, errorData);
+      case 'common':
+        throw new ApiCommonError(response.status, errorData);
+      default:
+        throw new ApiError(response.status, errorData);
+    }
   }
 
   const data = await response.json();
@@ -51,3 +59,7 @@ export class ApiError extends Error {
     this.data = data;
   }
 }
+
+export class ApiValidationError extends ApiError {}
+
+export class ApiCommonError extends ApiError {}

--- a/src/api/Auth.ts
+++ b/src/api/Auth.ts
@@ -1,0 +1,23 @@
+import {apiPost} from './Api.ts';
+import {ApiToken} from '../types/types.ts';
+
+export type RegUserData = {
+  name: string;
+  email: string;
+  password: string;
+  password_confirmation: string;
+  agree: boolean;
+};
+
+export const registerUser = (data: RegUserData): Promise<ApiToken> => {
+  return apiPost<ApiToken>('/auth/register', data);
+};
+
+export type LoginData = {
+  email: string;
+  password: string;
+};
+
+export const loginUser = (data: LoginData): Promise<ApiToken> => {
+  return apiPost<ApiToken>('/auth/login', data);
+};

--- a/src/api/Auth.ts
+++ b/src/api/Auth.ts
@@ -1,5 +1,6 @@
 import {apiPost} from './Api.ts';
 import {ApiToken} from '../types/types.ts';
+import {FieldValues} from 'react-hook-form';
 
 export type RegUserData = {
   name: string;
@@ -13,10 +14,10 @@ export const registerUser = (data: RegUserData): Promise<ApiToken> => {
   return apiPost<ApiToken>('/auth/register', data);
 };
 
-export type LoginData = {
+export interface LoginData extends FieldValues {
   email: string;
   password: string;
-};
+}
 
 export const loginUser = (data: LoginData): Promise<ApiToken> => {
   return apiPost<ApiToken>('/auth/login', data);

--- a/src/api/Auth.ts
+++ b/src/api/Auth.ts
@@ -2,13 +2,13 @@ import {apiPost} from './Api.ts';
 import {ApiToken} from '../types/types.ts';
 import {FieldValues} from 'react-hook-form';
 
-export type RegUserData = {
+export interface RegUserData extends FieldValues {
   name: string;
   email: string;
   password: string;
   password_confirmation: string;
   agree: boolean;
-};
+}
 
 export const registerUser = (data: RegUserData): Promise<ApiToken> => {
   return apiPost<ApiToken>('/auth/register', data);

--- a/src/components/InputError.tsx
+++ b/src/components/InputError.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {StyleSheet, Text} from 'react-native';
+
+type InputErrorProps = {
+  error: string | undefined;
+};
+
+const InputError = ({error}: InputErrorProps) => {
+  if (!error) {
+    return null;
+  }
+
+  return <Text style={styles.error}>{error}</Text>;
+};
+
+const styles = StyleSheet.create({
+  error: {
+    color: '#e63333',
+  },
+});
+
+export default InputError;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,119 @@
+import React, {
+  createContext,
+  useContext,
+  ReactNode,
+  useMemo,
+  useReducer,
+  useCallback,
+} from 'react';
+import {User} from '../types/types.ts';
+
+type LoginData = {
+  email: string;
+  password: string;
+};
+type AuthContextType = {
+  user: User | null;
+  isAuthenticated: boolean;
+  login: (data: LoginData) => void;
+  logout: () => void;
+  register: () => void;
+};
+type AuthState = {
+  isAuthenticated: boolean;
+  user: User | null;
+  isLoading: boolean;
+};
+type Action =
+  | {type: 'LOGIN'; payload: User}
+  | {type: 'POPULATE'; payload: User}
+  | {type: 'LOGOUT'};
+type AuthProviderProps = {
+  children: ReactNode;
+};
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+const reducer = (state: AuthState, action: Action) => {
+  switch (action.type) {
+    case 'LOGIN':
+      return {
+        ...state,
+        isAuthenticated: true,
+        user: action.payload,
+      };
+    case 'LOGOUT':
+      return {
+        ...state,
+        isAuthenticated: false,
+        user: null,
+      };
+    case 'POPULATE':
+      return {
+        ...state,
+        user: {
+          ...state.user,
+          ...action.payload,
+        },
+      };
+    default:
+      throw new Error('Unknown action type');
+  }
+};
+
+export const AuthProvider = ({children}: AuthProviderProps) => {
+  const [state, dispatch] = useReducer(reducer, {
+    user: null,
+    isAuthenticated: false,
+    isLoading: true,
+  });
+
+  const login = useCallback((data: LoginData) => {
+    // In a production app, we need to send some data (usually username, password) to server and get a token
+    // We will also need to handle errors if sign in failed
+    // After getting token, we need to persist the token using `SecureStore`
+    // In the example, we'll use a dummy token
+
+    if (data.email === 'Test' && data.password === '111') {
+      dispatch({type: 'LOGIN', payload: {id: 1, name: 'Ivan Artamonov'}});
+    } else {
+      throw new Error('Invalid credentials');
+    }
+  }, []);
+
+  const logout = useCallback(() => {
+    dispatch({type: 'LOGOUT'});
+  }, []);
+
+  const register = useCallback(() => {
+    // In a production app, we need to send user data to server and get a token
+    // We will also need to handle errors if sign up failed
+    // After getting token, we need to persist the token using `SecureStore`
+    // In the example, we'll use a dummy token
+
+    dispatch({type: 'LOGIN', payload: {id: 1, name: 'John Doe'}});
+  }, []);
+
+  const authContext = useMemo(
+    () => ({
+      user: state.user,
+      isAuthenticated: state.isAuthenticated,
+      login: login,
+      logout: logout,
+      register: register,
+    }),
+    [state, login, logout, register],
+  );
+
+  return (
+    <AuthContext.Provider value={authContext}>{children}</AuthContext.Provider>
+  );
+};
+
+export const useAuth = (): AuthContextType => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within a AuthProvider');
+  }
+  return context;
+};

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -65,11 +65,7 @@ export const AuthProvider = ({children}: AuthProviderProps) => {
       dispatch({type: 'LOGIN', payload: token});
     } catch (error) {
       if (error instanceof ApiError) {
-        if (error.status === 422) {
-          throw error;
-        } else {
-          console.error('API error:', error.data);
-        }
+        throw error;
       } else if (error instanceof Error) {
         console.error('Unexpected error:', error.message);
       } else {
@@ -91,11 +87,7 @@ export const AuthProvider = ({children}: AuthProviderProps) => {
       dispatch({type: 'LOGIN', payload: token});
     } catch (error) {
       if (error instanceof ApiError) {
-        if (error.status === 422) {
-          throw error;
-        } else {
-          console.error('API error:', error.data);
-        }
+        throw error;
       } else if (error instanceof Error) {
         console.error('Unexpected error:', error.message);
       } else {

--- a/src/navigation/StackNavigator.tsx
+++ b/src/navigation/StackNavigator.tsx
@@ -13,6 +13,7 @@ import SettingsScreen from '../screens/Settings/SettingsScreen.tsx';
 import PersonalInfoScreen from '../screens/PersonalInfo/PersonalInfoScreen.tsx';
 import SignInScreen from '../screens/SignIn/SignInScreen.tsx';
 import {useAuth} from '../contexts/AuthContext.tsx';
+import SignUpScreen from '../screens/SignUp/SignUpScreen.tsx';
 
 export type RootStackParamList = {
   TabNavigator: undefined;
@@ -20,6 +21,7 @@ export type RootStackParamList = {
   Settings: undefined;
   PersonalInfo: undefined;
   SignIn: undefined;
+  SignUp: undefined;
 };
 
 export type ScreenProps<RouteName extends keyof RootStackParamList> = {
@@ -79,6 +81,13 @@ const StackNavigator = () => {
               options={{
                 title: 'Sign In',
                 animationTypeForReplace: !isAuthenticated ? 'pop' : 'push',
+              }}
+            />
+            <Stack.Screen
+              name={'SignUp'}
+              component={SignUpScreen}
+              options={{
+                title: 'Sign Up',
               }}
             />
           </>

--- a/src/navigation/StackNavigator.tsx
+++ b/src/navigation/StackNavigator.tsx
@@ -11,12 +11,15 @@ import {Book} from '../types/types.ts';
 import Player from '../components/Player/Player.tsx';
 import SettingsScreen from '../screens/Settings/SettingsScreen.tsx';
 import PersonalInfoScreen from '../screens/PersonalInfo/PersonalInfoScreen.tsx';
+import SignInScreen from '../screens/SignIn/SignInScreen.tsx';
+import {useAuth} from '../contexts/AuthContext.tsx';
 
 export type RootStackParamList = {
   TabNavigator: undefined;
   BookDetails: {book: Book};
   Settings: undefined;
   PersonalInfo: undefined;
+  SignIn: undefined;
 };
 
 export type ScreenProps<RouteName extends keyof RootStackParamList> = {
@@ -31,6 +34,7 @@ export type ScreenProps<RouteName extends keyof RootStackParamList> = {
 const StackNavigator = () => {
   const Stack = createStackNavigator<RootStackParamList>();
   const {theme, isDark} = useTheme();
+  const {isAuthenticated} = useAuth();
 
   const NavigationTheme: Theme = {
     dark: isDark,
@@ -48,22 +52,37 @@ const StackNavigator = () => {
     <NavigationContainer theme={NavigationTheme}>
       <Player />
       <Stack.Navigator id="RootStackNav" screenOptions={{headerShown: false}}>
-        <Stack.Screen name="TabNavigator" component={TabNavigator} />
-        <Stack.Screen
-          name={'BookDetails'}
-          component={BookScreen}
-          options={{title: 'Book'}}
-        />
-        <Stack.Screen
-          name={'Settings'}
-          component={SettingsScreen}
-          options={{title: 'Settings'}}
-        />
-        <Stack.Screen
-          name={'PersonalInfo'}
-          component={PersonalInfoScreen}
-          options={{title: 'Personal Info'}}
-        />
+        {isAuthenticated ? (
+          <>
+            <Stack.Screen name="TabNavigator" component={TabNavigator} />
+            <Stack.Screen
+              name={'BookDetails'}
+              component={BookScreen}
+              options={{title: 'Book'}}
+            />
+            <Stack.Screen
+              name={'Settings'}
+              component={SettingsScreen}
+              options={{title: 'Settings'}}
+            />
+            <Stack.Screen
+              name={'PersonalInfo'}
+              component={PersonalInfoScreen}
+              options={{title: 'Personal Info'}}
+            />
+          </>
+        ) : (
+          <>
+            <Stack.Screen
+              name={'SignIn'}
+              component={SignInScreen}
+              options={{
+                title: 'Sign In',
+                animationTypeForReplace: !isAuthenticated ? 'pop' : 'push',
+              }}
+            />
+          </>
+        )}
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/screens/Book/BookScreen.tsx
+++ b/src/screens/Book/BookScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import {
   Image,
   ImageBackground,
@@ -28,7 +28,7 @@ function BookScreen({navigation, route}: BookScreenProps): React.JSX.Element {
   const {theme} = useTheme();
   const {startPlaying} = usePlayer();
   const [isLoading, setIsLoading] = useState(false);
-  const styles = styling(theme);
+  const styles = useMemo(() => styling(theme), [theme]);
 
   const handleListen = () => {
     setIsLoading(true);

--- a/src/screens/Book/BookScreen.tsx
+++ b/src/screens/Book/BookScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import {
   Image,
   ImageBackground,
@@ -30,7 +30,7 @@ function BookScreen({navigation, route}: BookScreenProps): React.JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
   const styles = useMemo(() => styling(theme), [theme]);
 
-  const handleListen = () => {
+  const handleListen = useCallback(() => {
     setIsLoading(true);
 
     // TODO: check for existing bookmark
@@ -45,9 +45,9 @@ function BookScreen({navigation, route}: BookScreenProps): React.JSX.Element {
         console.error('Failed to fetch first chapter:', error);
         setIsLoading(false);
       });
-  };
+  }, [startPlaying, book, setIsLoading]);
 
-  const handleShare = async () => {
+  const handleShare = useCallback(async () => {
     try {
       const result = await Share.share({
         message: book.title,
@@ -65,7 +65,7 @@ function BookScreen({navigation, route}: BookScreenProps): React.JSX.Element {
     } catch (error: any) {
       console.error(error.message);
     }
-  };
+  }, [book]);
 
   return (
     <>

--- a/src/screens/Home/HomeScreen.tsx
+++ b/src/screens/Home/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {
   ActivityIndicator,
   SafeAreaView,
@@ -19,8 +19,7 @@ function HomeScreen({}: HomeProps): React.JSX.Element {
   const {theme} = useTheme();
   const [loading, setLoading] = useState(false);
   const [widgets, setWidgets] = useState<Widget[]>([]);
-
-  const styles = styling(theme);
+  const styles = useMemo(() => styling(theme), [theme]);
 
   useEffect(() => {
     setLoading(true);

--- a/src/screens/PersonalInfo/PersonalInfoScreen.tsx
+++ b/src/screens/PersonalInfo/PersonalInfoScreen.tsx
@@ -6,6 +6,7 @@ import {ScreenProps} from '../../navigation/StackNavigator.tsx';
 import ScreenHeader from '../../components/ScreenHeader.tsx';
 import Pressable from '../../components/Pressable.tsx';
 import FontAwesome6 from 'react-native-vector-icons/FontAwesome6';
+import {useAuth} from '../../contexts/AuthContext.tsx';
 
 type PersonalInfoProps = ScreenProps<'PersonalInfo'>;
 
@@ -14,6 +15,7 @@ function PersonalInfoScreen({
 }: PersonalInfoProps): React.JSX.Element {
   const {theme} = useTheme();
   const styles = styling(theme);
+  const {logout} = useAuth();
 
   const handleDeleteAccount = () => {
     console.log('Account Deleted!');
@@ -31,6 +33,10 @@ function PersonalInfoScreen({
           </Text>
           <Text style={styles.text}>i.o.arta*****@gmail.com</Text>
         </View>
+        <Pressable style={styles.logoutButton} onPress={logout}>
+          <Text style={styles.deleteButtonText}>Вийти</Text>
+        </Pressable>
+
         <Pressable
           style={styles.deleteButton}
           onPress={() =>
@@ -78,6 +84,14 @@ const styling = (theme: Theme) =>
       color: theme.textMuted,
       fontSize: 14,
       paddingVertical: 5,
+    },
+    logoutButton: {
+      paddingVertical: 10,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.backgroundSoft,
+      borderRadius: 10,
+      marginVertical: 10,
     },
     deleteButton: {
       paddingVertical: 10,

--- a/src/screens/PersonalInfo/PersonalInfoScreen.tsx
+++ b/src/screens/PersonalInfo/PersonalInfoScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {Alert, SafeAreaView, StyleSheet, Text, View} from 'react-native';
 import {useTheme} from '../../contexts/ThemeContext.tsx';
 import {Theme} from '../../constants/theme.ts';
@@ -14,7 +14,7 @@ function PersonalInfoScreen({
   navigation,
 }: PersonalInfoProps): React.JSX.Element {
   const {theme} = useTheme();
-  const styles = styling(theme);
+  const styles = useMemo(() => styling(theme), [theme]);
   const {logout} = useAuth();
 
   const handleDeleteAccount = () => {

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {Linking, SafeAreaView, StyleSheet, Text, View} from 'react-native';
 import {ScreenProps} from '../../navigation/TabNavigator.tsx';
 import {useTheme} from '../../contexts/ThemeContext.tsx';
@@ -11,7 +11,7 @@ type ProfileProps = ScreenProps<'Profile'>;
 
 function ProfileScreen({navigation}: ProfileProps): React.JSX.Element {
   const {theme} = useTheme();
-  const styles = styling(theme);
+  const styles = useMemo(() => styling(theme), [theme]);
 
   const openWebsite = useCallback(async () => {
     await Linking.openURL(config.WEB_URL);

--- a/src/screens/Settings/SettingsScreen.tsx
+++ b/src/screens/Settings/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import {Appearance, SafeAreaView, StyleSheet, Text, View} from 'react-native';
 import {useTheme} from '../../contexts/ThemeContext.tsx';
 import {Theme} from '../../constants/theme.ts';
@@ -10,7 +10,7 @@ type SettingsProps = ScreenProps<'Settings'>;
 
 function SettingsScreen({navigation}: SettingsProps): React.JSX.Element {
   const {theme, isDark, setTheme, themeMode} = useTheme();
-  const styles = styling(theme);
+  const styles = useMemo(() => styling(theme), [theme]);
   const [useSystemTheme, setUseSystemTheme] = useState(themeMode === null);
 
   const toggleSystemTheme = () => {

--- a/src/screens/SignIn/SignInScreen.tsx
+++ b/src/screens/SignIn/SignInScreen.tsx
@@ -1,64 +1,22 @@
-import React, {useState} from 'react';
-import {Alert, SafeAreaView, StyleSheet, Text, View} from 'react-native';
+import React from 'react';
+import {SafeAreaView, StyleSheet, Text, View} from 'react-native';
 import {useTheme} from '../../contexts/ThemeContext.tsx';
 import {Theme} from '../../constants/theme.ts';
 import {ScreenProps} from '../../navigation/StackNavigator.tsx';
 import Pressable from '../../components/Pressable.tsx';
-import TextInput from '../../components/TextInput.tsx';
-import {useAuth} from '../../contexts/AuthContext.tsx';
-import {ApiError} from '../../api/Api.ts';
+import SignInForm from './components/SignInForm.tsx';
 
 type SignInProps = ScreenProps<'SignIn'>;
 
 function SignInScreen({navigation}: SignInProps): React.JSX.Element {
   const {theme} = useTheme();
-  const {login} = useAuth();
   const styles = styling(theme);
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-
-  const signIn = async () => {
-    try {
-      await login({email: email, password: password});
-    } catch (error) {
-      if (error instanceof ApiError) {
-        Alert.alert(error.message);
-      } else {
-        Alert.alert('An error occurred');
-      }
-    }
-  };
 
   return (
     <SafeAreaView>
       <View style={styles.container}>
         <Text style={styles.title}>Sign In</Text>
-        <TextInput
-          placeholder="Email"
-          style={styles.input}
-          defaultValue={email}
-          value={email}
-          onChangeText={setEmail}
-          autoComplete="email"
-          inputMode="email"
-          keyboardType="email-address"
-          textContentType="emailAddress"
-          autoCapitalize="none"
-        />
-        <TextInput
-          placeholder="Password"
-          secureTextEntry={true}
-          style={styles.input}
-          defaultValue={password}
-          value={password}
-          onChangeText={setPassword}
-          autoComplete="password"
-          textContentType="password"
-          autoCapitalize="none"
-        />
-        <Pressable onPress={signIn} style={styles.button}>
-          <Text style={styles.buttonText}>Sign In</Text>
-        </Pressable>
+        <SignInForm />
         <Pressable
           onPress={() => navigation.navigate('SignUp')}
           style={styles.registerButton}>
@@ -82,15 +40,6 @@ const styling = (theme: Theme) =>
       color: theme.text,
       alignSelf: 'center',
       marginBottom: 20,
-    },
-    input: {
-      marginTop: 10,
-    },
-    button: {
-      backgroundColor: theme.primary,
-      padding: 10,
-      borderRadius: 5,
-      marginTop: 20,
     },
     buttonText: {
       fontSize: 16,

--- a/src/screens/SignIn/SignInScreen.tsx
+++ b/src/screens/SignIn/SignInScreen.tsx
@@ -1,0 +1,89 @@
+import React, {useState} from 'react';
+import {Alert, SafeAreaView, StyleSheet, Text, View} from 'react-native';
+import {useTheme} from '../../contexts/ThemeContext.tsx';
+import {Theme} from '../../constants/theme.ts';
+import {ScreenProps} from '../../navigation/StackNavigator.tsx';
+import Pressable from '../../components/Pressable.tsx';
+import TextInput from '../../components/TextInput.tsx';
+import {useAuth} from '../../contexts/AuthContext.tsx';
+
+type SignInProps = ScreenProps<'SignIn'>;
+
+function SignInScreen({}: SignInProps): React.JSX.Element {
+  const {theme} = useTheme();
+  const {login} = useAuth();
+  const styles = styling(theme);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const signIn = () => {
+    try {
+      login({email: email, password: password});
+    } catch (error) {
+      if (error instanceof Error) {
+        Alert.alert(error.message);
+      } else {
+        Alert.alert('An error occurred');
+      }
+    }
+  };
+
+  return (
+    <SafeAreaView>
+      <View style={styles.container}>
+        <Text style={styles.title}>Sign In</Text>
+        <TextInput
+          placeholder="Email"
+          style={styles.input}
+          defaultValue={email}
+          value={email}
+          onChangeText={setEmail}
+        />
+        <TextInput
+          placeholder="Password"
+          secureTextEntry={true}
+          style={styles.input}
+          defaultValue={password}
+          value={password}
+          onChangeText={setPassword}
+        />
+        <Pressable onPress={signIn} style={styles.button}>
+          <Text style={styles.buttonText}>Sign In</Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styling = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      height: '100%',
+      justifyContent: 'center',
+      paddingHorizontal: 20,
+    },
+    title: {
+      fontSize: 32,
+      fontWeight: 'bold',
+      color: theme.text,
+      alignSelf: 'center',
+      marginBottom: 20,
+    },
+    input: {
+      marginTop: 10,
+    },
+    button: {
+      backgroundColor: theme.primary,
+      padding: 10,
+      borderRadius: 5,
+      marginTop: 20,
+    },
+    buttonText: {
+      fontSize: 16,
+      fontWeight: '500',
+      color: theme.text,
+      textAlign: 'center',
+    },
+  });
+
+export default SignInScreen;

--- a/src/screens/SignIn/SignInScreen.tsx
+++ b/src/screens/SignIn/SignInScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {SafeAreaView, StyleSheet, Text, View} from 'react-native';
 import {useTheme} from '../../contexts/ThemeContext.tsx';
 import {Theme} from '../../constants/theme.ts';
@@ -10,7 +10,7 @@ type SignInProps = ScreenProps<'SignIn'>;
 
 function SignInScreen({navigation}: SignInProps): React.JSX.Element {
   const {theme} = useTheme();
-  const styles = styling(theme);
+  const styles = useMemo(() => styling(theme), [theme]);
 
   return (
     <SafeAreaView>

--- a/src/screens/SignIn/SignInScreen.tsx
+++ b/src/screens/SignIn/SignInScreen.tsx
@@ -43,6 +43,7 @@ function SignInScreen({navigation}: SignInProps): React.JSX.Element {
           inputMode="email"
           keyboardType="email-address"
           textContentType="emailAddress"
+          autoCapitalize="none"
         />
         <TextInput
           placeholder="Password"
@@ -53,6 +54,7 @@ function SignInScreen({navigation}: SignInProps): React.JSX.Element {
           onChangeText={setPassword}
           autoComplete="password"
           textContentType="password"
+          autoCapitalize="none"
         />
         <Pressable onPress={signIn} style={styles.button}>
           <Text style={styles.buttonText}>Sign In</Text>

--- a/src/screens/SignIn/components/SignInForm.tsx
+++ b/src/screens/SignIn/components/SignInForm.tsx
@@ -1,0 +1,80 @@
+import React, {useState} from 'react';
+import TextInput from '../../../components/TextInput.tsx';
+import Pressable from '../../../components/Pressable.tsx';
+import {Alert, StyleSheet, Text} from 'react-native';
+import {ApiError} from '../../../api/Api.ts';
+import {useAuth} from '../../../contexts/AuthContext.tsx';
+import {useTheme} from '../../../contexts/ThemeContext.tsx';
+import {Theme} from '../../../constants/theme.ts';
+
+const SignInForm = () => {
+  const {login} = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const {theme} = useTheme();
+  const styles = styling(theme);
+
+  const signIn = async () => {
+    try {
+      await login({email: email, password: password});
+    } catch (error) {
+      if (error instanceof ApiError) {
+        Alert.alert(error.message);
+      } else {
+        Alert.alert('An error occurred');
+      }
+    }
+  };
+
+  return (
+    <>
+      <TextInput
+        placeholder="Email"
+        style={styles.input}
+        defaultValue={email}
+        value={email}
+        onChangeText={setEmail}
+        autoComplete="email"
+        inputMode="email"
+        keyboardType="email-address"
+        textContentType="emailAddress"
+        autoCapitalize="none"
+      />
+      <TextInput
+        placeholder="Password"
+        secureTextEntry={true}
+        style={styles.input}
+        defaultValue={password}
+        value={password}
+        onChangeText={setPassword}
+        autoComplete="password"
+        textContentType="password"
+        autoCapitalize="none"
+      />
+      <Pressable onPress={signIn} style={styles.button}>
+        <Text style={styles.buttonText}>Sign In</Text>
+      </Pressable>
+    </>
+  );
+};
+
+const styling = (theme: Theme) =>
+  StyleSheet.create({
+    input: {
+      marginTop: 10,
+    },
+    button: {
+      backgroundColor: theme.primary,
+      padding: 10,
+      borderRadius: 5,
+      marginTop: 20,
+    },
+    buttonText: {
+      fontSize: 16,
+      fontWeight: '500',
+      color: 'white',
+      textAlign: 'center',
+    },
+  });
+
+export default SignInForm;

--- a/src/screens/SignIn/components/SignInForm.tsx
+++ b/src/screens/SignIn/components/SignInForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import TextInput from '../../../components/TextInput.tsx';
 import Pressable from '../../../components/Pressable.tsx';
 import {Alert, StyleSheet, Text} from 'react-native';
@@ -13,7 +13,7 @@ import InputError from '../../../components/InputError.tsx';
 const SignInForm = () => {
   const {login} = useAuth();
   const {theme} = useTheme();
-  const styles = styling(theme);
+  const styles = useMemo(() => styling(theme), [theme]);
   const {
     control,
     handleSubmit,

--- a/src/screens/SignUp/SignUpScreen.tsx
+++ b/src/screens/SignUp/SignUpScreen.tsx
@@ -1,87 +1,24 @@
-import React, {useState} from 'react';
-import {Alert, SafeAreaView, StyleSheet, Text, View} from 'react-native';
+import React from 'react';
+import {SafeAreaView, StyleSheet, Text, View} from 'react-native';
 import {useTheme} from '../../contexts/ThemeContext.tsx';
 import {Theme} from '../../constants/theme.ts';
 import {ScreenProps} from '../../navigation/StackNavigator.tsx';
 import Pressable from '../../components/Pressable.tsx';
-import TextInput from '../../components/TextInput.tsx';
-import {useAuth} from '../../contexts/AuthContext.tsx';
+import SignUpForm from './components/SignUpForm.tsx';
 
 type SignUpProps = ScreenProps<'SignUp'>;
 
 function SignUpScreen({navigation}: SignUpProps): React.JSX.Element {
   const {theme} = useTheme();
-  const {register} = useAuth();
   const styles = styling(theme);
-  const [email, setEmail] = useState('');
-  const [name, setName] = useState('');
-  const [password, setPassword] = useState('');
-  const [passwordConfirmation, setPasswordConfirmation] = useState('');
-
-  const signUp = () => {
-    try {
-      register({
-        email: email,
-        name: name,
-        password: password,
-        password_confirmation: passwordConfirmation,
-        agree: true,
-      });
-    } catch (error) {
-      if (error instanceof Error) {
-        Alert.alert(error.message);
-      } else {
-        Alert.alert('An error occurred');
-      }
-    }
-  };
 
   return (
     <SafeAreaView>
       <View style={styles.container}>
         <Text style={styles.title}>Registration</Text>
-        <TextInput
-          placeholder="Name"
-          style={styles.input}
-          defaultValue={name}
-          value={name}
-          onChangeText={setName}
-          autoComplete="name"
-          textContentType="name"
-        />
-        <TextInput
-          placeholder="Email"
-          style={styles.input}
-          defaultValue={email}
-          value={email}
-          onChangeText={setEmail}
-          autoComplete="email"
-          inputMode="email"
-          keyboardType="email-address"
-          textContentType="emailAddress"
-          autoCapitalize="none"
-        />
-        <TextInput
-          placeholder="Password"
-          secureTextEntry={true}
-          style={styles.input}
-          defaultValue={password}
-          value={password}
-          onChangeText={setPassword}
-          autoCapitalize="none"
-        />
-        <TextInput
-          placeholder="Confirm Password"
-          secureTextEntry={true}
-          style={styles.input}
-          defaultValue={passwordConfirmation}
-          value={passwordConfirmation}
-          onChangeText={setPasswordConfirmation}
-          autoCapitalize="none"
-        />
-        <Pressable onPress={signUp} style={styles.button}>
-          <Text style={styles.buttonText}>Register</Text>
-        </Pressable>
+
+        <SignUpForm />
+
         <Pressable
           onPress={() => navigation.navigate('SignIn')}
           style={styles.registerButton}>
@@ -106,15 +43,6 @@ const styling = (theme: Theme) =>
       color: theme.text,
       alignSelf: 'center',
       marginBottom: 20,
-    },
-    input: {
-      marginTop: 10,
-    },
-    button: {
-      backgroundColor: theme.primary,
-      padding: 10,
-      borderRadius: 5,
-      marginTop: 20,
     },
     buttonText: {
       fontSize: 16,

--- a/src/screens/SignUp/SignUpScreen.tsx
+++ b/src/screens/SignUp/SignUpScreen.tsx
@@ -6,22 +6,29 @@ import {ScreenProps} from '../../navigation/StackNavigator.tsx';
 import Pressable from '../../components/Pressable.tsx';
 import TextInput from '../../components/TextInput.tsx';
 import {useAuth} from '../../contexts/AuthContext.tsx';
-import {ApiError} from '../../api/Api.ts';
 
-type SignInProps = ScreenProps<'SignIn'>;
+type SignUpProps = ScreenProps<'SignUp'>;
 
-function SignInScreen({navigation}: SignInProps): React.JSX.Element {
+function SignUpScreen({navigation}: SignUpProps): React.JSX.Element {
   const {theme} = useTheme();
-  const {login} = useAuth();
+  const {register} = useAuth();
   const styles = styling(theme);
   const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
   const [password, setPassword] = useState('');
+  const [passwordConfirmation, setPasswordConfirmation] = useState('');
 
-  const signIn = async () => {
+  const signUp = () => {
     try {
-      await login({email: email, password: password});
+      register({
+        email: email,
+        name: name,
+        password: password,
+        password_confirmation: passwordConfirmation,
+        agree: true,
+      });
     } catch (error) {
-      if (error instanceof ApiError) {
+      if (error instanceof Error) {
         Alert.alert(error.message);
       } else {
         Alert.alert('An error occurred');
@@ -32,7 +39,16 @@ function SignInScreen({navigation}: SignInProps): React.JSX.Element {
   return (
     <SafeAreaView>
       <View style={styles.container}>
-        <Text style={styles.title}>Sign In</Text>
+        <Text style={styles.title}>Registration</Text>
+        <TextInput
+          placeholder="Name"
+          style={styles.input}
+          defaultValue={name}
+          value={name}
+          onChangeText={setName}
+          autoComplete="name"
+          textContentType="name"
+        />
         <TextInput
           placeholder="Email"
           style={styles.input}
@@ -51,16 +67,23 @@ function SignInScreen({navigation}: SignInProps): React.JSX.Element {
           defaultValue={password}
           value={password}
           onChangeText={setPassword}
-          autoComplete="password"
-          textContentType="password"
         />
-        <Pressable onPress={signIn} style={styles.button}>
-          <Text style={styles.buttonText}>Sign In</Text>
+        <TextInput
+          placeholder="Confirm Password"
+          secureTextEntry={true}
+          style={styles.input}
+          defaultValue={passwordConfirmation}
+          value={passwordConfirmation}
+          onChangeText={setPasswordConfirmation}
+        />
+        <Pressable onPress={signUp} style={styles.button}>
+          <Text style={styles.buttonText}>Register</Text>
         </Pressable>
         <Pressable
-          onPress={() => navigation.navigate('SignUp')}
+          onPress={() => navigation.navigate('SignIn')}
           style={styles.registerButton}>
-          <Text style={styles.buttonText}>Register</Text>
+          <Text style={styles.buttonTextSoft}>Already have an account?</Text>
+          <Text style={styles.buttonText}>Log in</Text>
         </Pressable>
       </View>
     </SafeAreaView>
@@ -100,6 +123,12 @@ const styling = (theme: Theme) =>
       padding: 10,
       marginTop: 20,
     },
+    buttonTextSoft: {
+      color: theme.textSoft,
+      fontSize: 16,
+      fontWeight: '500',
+      textAlign: 'center',
+    },
   });
 
-export default SignInScreen;
+export default SignUpScreen;

--- a/src/screens/SignUp/SignUpScreen.tsx
+++ b/src/screens/SignUp/SignUpScreen.tsx
@@ -59,6 +59,7 @@ function SignUpScreen({navigation}: SignUpProps): React.JSX.Element {
           inputMode="email"
           keyboardType="email-address"
           textContentType="emailAddress"
+          autoCapitalize="none"
         />
         <TextInput
           placeholder="Password"
@@ -67,6 +68,7 @@ function SignUpScreen({navigation}: SignUpProps): React.JSX.Element {
           defaultValue={password}
           value={password}
           onChangeText={setPassword}
+          autoCapitalize="none"
         />
         <TextInput
           placeholder="Confirm Password"
@@ -75,6 +77,7 @@ function SignUpScreen({navigation}: SignUpProps): React.JSX.Element {
           defaultValue={passwordConfirmation}
           value={passwordConfirmation}
           onChangeText={setPasswordConfirmation}
+          autoCapitalize="none"
         />
         <Pressable onPress={signUp} style={styles.button}>
           <Text style={styles.buttonText}>Register</Text>

--- a/src/screens/SignUp/SignUpScreen.tsx
+++ b/src/screens/SignUp/SignUpScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {SafeAreaView, StyleSheet, Text, View} from 'react-native';
 import {useTheme} from '../../contexts/ThemeContext.tsx';
 import {Theme} from '../../constants/theme.ts';
@@ -10,7 +10,7 @@ type SignUpProps = ScreenProps<'SignUp'>;
 
 function SignUpScreen({navigation}: SignUpProps): React.JSX.Element {
   const {theme} = useTheme();
-  const styles = styling(theme);
+  const styles = useMemo(() => styling(theme), [theme]);
 
   return (
     <SafeAreaView>

--- a/src/screens/SignUp/components/SignUpForm.tsx
+++ b/src/screens/SignUp/components/SignUpForm.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import TextInput from '../../../components/TextInput.tsx';
+import Pressable from '../../../components/Pressable.tsx';
+import {Alert, StyleSheet, Text} from 'react-native';
+import {useAuth} from '../../../contexts/AuthContext.tsx';
+import {useTheme} from '../../../contexts/ThemeContext.tsx';
+import {Controller, useForm} from 'react-hook-form';
+import {RegUserData} from '../../../api/Auth.ts';
+import {ApiCommonError, ApiValidationError} from '../../../api/Api.ts';
+import {Theme} from '../../../constants/theme.ts';
+import InputError from '../../../components/InputError.tsx';
+
+const SignUpForm = () => {
+  const {register} = useAuth();
+  const {theme} = useTheme();
+  const styles = styling(theme);
+  const {
+    control,
+    handleSubmit,
+    setError,
+    formState: {errors},
+  } = useForm<RegUserData>();
+
+  const onSubmit = async (data: RegUserData) => {
+    try {
+      data.agree = true;
+      await register(data);
+    } catch (error: any) {
+      if (error instanceof ApiValidationError) {
+        error.fillFormErrors(setError);
+      } else if (error instanceof ApiCommonError) {
+        Alert.alert(error.message);
+      } else {
+        Alert.alert('Unknown error occurred');
+      }
+    }
+  };
+
+  return (
+    <>
+      <Controller
+        control={control}
+        name="name"
+        rules={{required: 'Name is required'}}
+        render={({field: {onChange, onBlur, value}}) => (
+          <TextInput
+            placeholder="Name"
+            style={styles.input}
+            value={value}
+            onBlur={onBlur}
+            onChangeText={onChange}
+            autoComplete="name"
+            textContentType="name"
+          />
+        )}
+      />
+      <InputError error={errors.name?.message} />
+
+      <Controller
+        control={control}
+        name="email"
+        rules={{required: 'Email is required'}}
+        render={({field: {onChange, onBlur, value}}) => (
+          <TextInput
+            placeholder="Email"
+            style={styles.input}
+            value={value}
+            onBlur={onBlur}
+            onChangeText={onChange}
+            autoComplete="email"
+            inputMode="email"
+            keyboardType="email-address"
+            textContentType="emailAddress"
+            autoCapitalize="none"
+          />
+        )}
+      />
+      <InputError error={errors.email?.message} />
+
+      <Controller
+        control={control}
+        name="password"
+        rules={{required: 'Password is required'}}
+        render={({field: {onChange, onBlur, value}}) => (
+          <TextInput
+            placeholder="Password"
+            style={styles.input}
+            secureTextEntry={true}
+            value={value}
+            onBlur={onBlur}
+            onChangeText={onChange}
+            autoCapitalize="none"
+          />
+        )}
+      />
+      <InputError error={errors.password?.message} />
+
+      <Controller
+        control={control}
+        name="password_confirmation"
+        rules={{required: 'Password confirmation is required'}}
+        render={({field: {onChange, onBlur, value}}) => (
+          <TextInput
+            placeholder="Password Confirmation"
+            style={styles.input}
+            secureTextEntry={true}
+            value={value}
+            onBlur={onBlur}
+            onChangeText={onChange}
+            autoCapitalize="none"
+          />
+        )}
+      />
+      <InputError error={errors.password_confirmation?.message} />
+
+      <Pressable onPress={handleSubmit(onSubmit)} style={styles.button}>
+        <Text style={styles.buttonText}>Register</Text>
+      </Pressable>
+    </>
+  );
+};
+
+const styling = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      height: '100%',
+      justifyContent: 'center',
+      paddingHorizontal: 20,
+    },
+    title: {
+      fontSize: 32,
+      fontWeight: 'bold',
+      color: theme.text,
+      alignSelf: 'center',
+      marginBottom: 20,
+    },
+    input: {
+      marginTop: 10,
+    },
+    button: {
+      backgroundColor: theme.primary,
+      padding: 10,
+      borderRadius: 5,
+      marginTop: 20,
+    },
+    buttonText: {
+      fontSize: 16,
+      fontWeight: '500',
+      color: 'white',
+      textAlign: 'center',
+    },
+    registerButton: {
+      padding: 10,
+      marginTop: 20,
+    },
+    buttonTextSoft: {
+      color: theme.textSoft,
+      fontSize: 16,
+      fontWeight: '500',
+      textAlign: 'center',
+    },
+  });
+
+export default SignUpForm;

--- a/src/screens/SignUp/components/SignUpForm.tsx
+++ b/src/screens/SignUp/components/SignUpForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import TextInput from '../../../components/TextInput.tsx';
 import Pressable from '../../../components/Pressable.tsx';
 import {Alert, StyleSheet, Text} from 'react-native';
@@ -13,7 +13,7 @@ import InputError from '../../../components/InputError.tsx';
 const SignUpForm = () => {
   const {register} = useAuth();
   const {theme} = useTheme();
-  const styles = styling(theme);
+  const styles = useMemo(() => styling(theme), [theme]);
   const {
     control,
     handleSubmit,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -70,3 +70,5 @@ export interface User {
   id: number;
   name: string;
 }
+
+export type ApiToken = string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -65,3 +65,8 @@ export interface Widget {
   title: string;
   books: Book[];
 }
+
+export interface User {
+  id: number;
+  name: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5765,6 +5765,11 @@ react-freeze@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-freeze/-/react-freeze-1.0.4.tgz#cbbea2762b0368b05cbe407ddc9d518c57c6f3ad"
   integrity sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==
 
+react-hook-form@^7.51.4:
+  version "7.51.4"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.51.4.tgz#c3a47aeb22b699c45de9fc12b58763606cb52f0c"
+  integrity sha512-V14i8SEkh+V1gs6YtD0hdHYnoL4tp/HX/A45wWQN15CYr9bFRmmRdYStSO5L65lCCZRF+kYiSKhm9alqbcdiVA==
+
 "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"


### PR DESCRIPTION
В цьому PR я додав реєстрацію та автентифікацію (в базовому виконанні).

1. Логін \ Логаут в навігації зробив відповідно [до документації](https://reactnavigation.org/docs/auth-flow)
2. Додав нові API ендпоінти для реєстрації\автентифікації
3. Створив AuthContext зі всією необхідною інфою, внутрі використав useReducer() хук
4. Заніс у проект [React Hook Form](https://react-hook-form.com/) та використав його у формах логіну і реєстрації

**Питання:**
1. Подивіться будь ласка на [src/api/Api.ts](https://github.com/ivanartamonov/voicebook/blob/852e6d08def7fa30963a167014cad99400132a23/src/api/Api.ts). Щось він якийсь "бруднуватий". Там оголошені методи `apiReuest()`, `apiGet()` та `apiPost()`, тут все ок, все логічно. Але у цьому ж файлі й оголошені класи помилок (ексепшени) `ApiError`, `ApiValidationError` та `ApiCommonError`, - ось вони здається тут зайві у цьому файлі. Але куди їх краще?
2. Загляніть у файл [src/api/Auth.ts](https://github.com/ivanartamonov/voicebook/blob/852e6d08def7fa30963a167014cad99400132a23/src/api/Auth.ts). Там є дві функції `registerUser()` та `loginUser()` і оголошені відповідні типи даних, які приймають ці функції. З одного боку все ок, але ці типи даних наслідуються від `FieldValues` який у свою чергу імпортується з ReactHookForm. Це необхідно, щоб працювала функція `ApiValidationError.fillFormErrors()`. Я не знаю, як у фронтенді, але у нас в бекенді це було б помилкою. Бо цей API файлік - він як найнижчий рівень - Data Layer або Infrastructure Layer. А тип `FieldValues` належить до рівня UI або Presentation Layer. А не може нижчий рівень нічого знати про вищий, тільки в зворотньому напрямку і тільки до наступного нижчого слою без стрибків через слой. А тут у нас рівень, який працює з даними якимось чином знає про рівень UI, який на самом верху. Я так зрозумів, що у світі Frontend'у цим особливо ніхто не заморочується. Чи все ж таки треба це інакше якось зробити?
3. Не впевнений, що правильно організував Error Handling. Ось наприклад,
<img width="626" alt="image" src="https://github.com/ivanartamonov/voicebook/assets/7717669/e3958f9b-539a-472d-91b5-2f5445500834">

У нас є власний тип помилок `ApiError` (і два її наслідника `ApiValidationError` і `ApiCommonError`) - це "контрольовані" помилки. Тобто вони можуть виникати, наприклад через валідацію на бекенді, це нормально, ми їх опрацьовуємо і відображаємо користувачу. Таке опрацювання ми не робимо прям тут у `AuthProvider`, а робимо безпосередньо в компоненті екрана, де там відображається форма логіна. Тому просто робимо `throw error` далі. Якщо це не ApiError, то щось пішло не так і тут треба вже залогувати помилку в Sentry і показати (а іноді можливо і не показувати?) користувачу стандартний Alert з текстом "Вибачте, виникла помилка, спробуйте ще". І питання як це організувати? Таких місць може бути багато, всюди руками писати виклик Sentry? А стандартний Alert теж тут викликати? Це здається неправильно. Бо це місце, де трапляється помилка може взагалі нічого не знати про UI слой. І неправильно, щоб воно запускало Alert. Як це правильно організувати?

Дякую за ревью :)